### PR TITLE
fix(cypress): add load fixtures condition [HOZ-3203]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker build -t hozanaci/backend:latest .
 # docker push hozanaci/backend:latest
 #
-FROM php:8.1-fpm
+FROM --platform=linux/amd64 php:8.1-fpm
 LABEL org.opencontainers.image.authors="marco@hozana.org"
 
 # nvm environment variables
@@ -14,66 +14,66 @@ ENV NVM_DIR /usr/local/nvm
 
 # Add necesary libraries
 RUN apt-get update \
-    && apt-get upgrade -y --allow-unauthenticated \
-    && apt-get install -y --allow-unauthenticated \
-        apt-transport-https \
-        libfcgi0ldbl \
-        curl \
-        pv \
-        rsync \
-        git \
-        libpcre3-dev \
-        net-tools \
-        rsyslog \
-        zlib1g-dev \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libjpeg62-turbo \
-        libjpeg-turbo-progs \
-        libpng-dev \
-        libgmp-dev \
-        libwebp-dev \
-        libexif-dev \
-        libxpm-dev \
-        libzip-dev \
-        zip \
-        unzip \
-        gnupg \
-        libicu-dev \
-        ghostscript \
-        build-essential \
-        libssl-dev \
-        libonig-dev \
-        librabbitmq-dev \
-        libxml2-dev libxslt-dev \
-        locales \
-        vim \
-        mycli \
-    && docker-php-ext-configure gd --with-jpeg --with-webp \
-    && docker-php-ext-configure gmp \
-    && docker-php-ext-configure intl
+  && apt-get upgrade -y --allow-unauthenticated \
+  && apt-get install -y --allow-unauthenticated \
+  apt-transport-https \
+  libfcgi0ldbl \
+  curl \
+  pv \
+  rsync \
+  git \
+  libpcre3-dev \
+  net-tools \
+  rsyslog \
+  zlib1g-dev \
+  libfreetype6-dev \
+  libjpeg62-turbo-dev \
+  libjpeg62-turbo \
+  libjpeg-turbo-progs \
+  libpng-dev \
+  libgmp-dev \
+  libwebp-dev \
+  libexif-dev \
+  libxpm-dev \
+  libzip-dev \
+  zip \
+  unzip \
+  gnupg \
+  libicu-dev \
+  ghostscript \
+  build-essential \
+  libssl-dev \
+  libonig-dev \
+  librabbitmq-dev \
+  libxml2-dev libxslt-dev \
+  locales \
+  vim \
+  mycli \
+  && docker-php-ext-configure gd --with-jpeg --with-webp \
+  && docker-php-ext-configure gmp \
+  && docker-php-ext-configure intl
 
 # Add PHP extensions
 RUN docker-php-ext-install \
-    mbstring \
-    pdo \
-    pdo_mysql \
-    zip \
-    gd \
-    exif \
-    gmp \
-    intl \
-    opcache \
-    xsl \
-    pcntl
+  mbstring \
+  pdo \
+  pdo_mysql \
+  zip \
+  gd \
+  exif \
+  gmp \
+  intl \
+  opcache \
+  xsl \
+  pcntl
 
 RUN mkdir -p $NVM_DIR && curl -s -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 
 # install node and npm
 RUN . $NVM_DIR/nvm.sh \
-    && nvm install $NODE_VERSION \
-    && nvm alias default $NODE_VERSION \
-    && nvm use default
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default
 
 # add node and npm to path so the commands are available
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
@@ -90,9 +90,9 @@ ENV LC_ALL en_US.UTF-8
 
 # add PECL extensions
 RUN pecl install xdebug && docker-php-ext-enable xdebug && \
-    pecl install redis && docker-php-ext-enable redis && \
-    pecl install amqp && docker-php-ext-enable amqp && \
-    pecl install apcu && docker-php-ext-enable apcu
+  pecl install redis && docker-php-ext-enable redis && \
+  pecl install amqp && docker-php-ext-enable amqp && \
+  pecl install apcu && docker-php-ext-enable apcu
 
 # Configure PHP
 COPY usr/local/etc/php-fpm.d/www.conf /usr/local/etc/php-fpm.d/www.conf 
@@ -137,13 +137,13 @@ COPY usr/local/sbin/install_composer.sh /usr/local/sbin/install_composer.sh
 COPY usr/local/bin/docker-php-entrypoint /usr/local/bin/docker-php-entrypoint
 
 RUN /usr/local/sbin/install_composer.sh \
- && mkdir -p /.composer && chmod -R 777 /.composer \
- && cd /data/code \
- && HOZANA_DB_URL=sqlite:///:memory: \
- && HOZANA_DB_E2E_URL=sqlite:///:memory: \
- && HOZANA_CRM_DB_URL=sqlite:///:memory: \
- && COMPOSER_ALLOW_SUPERUSER=1 composer install --prefer-dist --no-progress --no-interaction \
- && yarn install 
+  && mkdir -p /.composer && chmod -R 777 /.composer \
+  && cd /data/code \
+  && HOZANA_DB_URL=sqlite:///:memory: \
+  && HOZANA_DB_E2E_URL=sqlite:///:memory: \
+  && HOZANA_CRM_DB_URL=sqlite:///:memory: \
+  && COMPOSER_ALLOW_SUPERUSER=1 composer install --prefer-dist --no-progress --no-interaction \
+  && yarn install 
 
 # Docker entrypoint
 #COPY ./tools/docker/scripts/docker-entrypoint.sh /data/scripts/
@@ -154,20 +154,20 @@ VOLUME ["/data/code"]
 #COPY ./tools/docker/backend/entrypoint.sh /usr/local/bin/
 
 RUN docker-php-source delete && \
-    rm -r /tmp/* /var/cache/*
+  rm -r /tmp/* /var/cache/*
 
 CMD php-fpm
 ENTRYPOINT ["/usr/local/bin/docker-php-entrypoint"]
 HEALTHCHECK --interval=15s \
-    --timeout=30s \
-    --start-period=30s \
-    --retries=10 \
-    CMD SCRIPT_FILENAME=/data/code/public/index.php \
-        SCRIPT_NAME=/api/fr/server-info \
-        REQUEST_URI=/api/fr/server-info \
-        QUERY_STRING= \
-        REQUEST_METHOD=GET \
-        SERVER_NAME=hozana.local \
-        SERVER_PORT=443 \
-        HTTPS=true \
-        cgi-fcgi -bind -connect localhost:9000 || exit 1
+  --timeout=30s \
+  --start-period=30s \
+  --retries=10 \
+  CMD SCRIPT_FILENAME=/data/code/public/index.php \
+  SCRIPT_NAME=/api/fr/server-info \
+  REQUEST_URI=/api/fr/server-info \
+  QUERY_STRING= \
+  REQUEST_METHOD=GET \
+  SERVER_NAME=hozana.local \
+  SERVER_PORT=443 \
+  HTTPS=true \
+  cgi-fcgi -bind -connect localhost:9000 || exit 1

--- a/usr/local/bin/docker-php-entrypoint
+++ b/usr/local/bin/docker-php-entrypoint
@@ -135,7 +135,7 @@ if [ "$APP_ENV" != 'prod' ]; then
     fi
 
     if [ "$APP_ENV"  = 'ci' ]; then
-        bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm --purge-with-truncate
+        bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm
         bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
     fi
 

--- a/usr/local/bin/docker-php-entrypoint
+++ b/usr/local/bin/docker-php-entrypoint
@@ -114,7 +114,7 @@ if [ "$APP_ENV" != 'prod' ]; then
 
     # Wait for elasticsearch before init and index.
     echo -n "------ Waiting for elasticsearch to be ready..."
-    until bin/console api:elasticsearch:init --health-check > /dev/null 2>&1; do
+    until bin/console api:elasticsearch:init --health-check --no-interaction > /dev/null 2>&1; do
         echo -n .
         sleep 5
     done
@@ -122,7 +122,7 @@ if [ "$APP_ENV" != 'prod' ]; then
     echo -e "${GREEN_BG} [OK] Elasticsearch is UP!  ${RESET}"
     echo -e "${GREEN_BG}                            ${RESET}\n"
 
-    bin/console api:elasticsearch:init
+    bin/console api:elasticsearch:init --no-interaction
 
     # check if we need to load fixtures for first bootstrap.
     NEED_FIXTURES=$(bin/console doctrine:query:sql 'SELECT COUNT(guide_id) FROM guides' | sed -n '/[0-9]/s/[^0-9]//gp')
@@ -134,7 +134,12 @@ if [ "$APP_ENV" != 'prod' ]; then
         bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
     fi
 
-    bin/console api:elasticsearch:index
+    if [ "$LOAD_FIXTURES" = 'true' ]; then
+        bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm --purge-with-truncate
+        bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
+    fi
+
+    bin/console api:elasticsearch:index --no-interaction
 fi
 
 chown -R www-data:www-data /data/code/var/log /data/code/var/cache /data/code/public/build/mails

--- a/usr/local/bin/docker-php-entrypoint
+++ b/usr/local/bin/docker-php-entrypoint
@@ -134,7 +134,7 @@ if [ "$APP_ENV" != 'prod' ]; then
         bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
     fi
 
-    if [ "$LOAD_FIXTURES" = 'true' ]; then
+    if [ "$APP_ENV"  = 'ci' ]; then
         bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm --purge-with-truncate
         bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
     fi

--- a/usr/local/bin/docker-php-entrypoint
+++ b/usr/local/bin/docker-php-entrypoint
@@ -136,7 +136,7 @@ if [ "$APP_ENV" != 'prod' ]; then
 
     if [ "$APP_ENV"  = 'ci' ]; then
         bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm
-        bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
+        bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n
     fi
 
     bin/console api:elasticsearch:index --no-interaction

--- a/usr/local/bin/docker-php-entrypoint
+++ b/usr/local/bin/docker-php-entrypoint
@@ -134,7 +134,7 @@ if [ "$APP_ENV" != 'prod' ]; then
         bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
     fi
 
-    if [ "$APP_ENV"  = 'ci' ]; then
+    if { [[ "$APP_ENV" == "dev" ]] || [[ "$APP_ENV" == "ci" ]]; } && [[ "$NEED_FIXTURES" == "true" ]]; then
         bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm
         bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n
     fi


### PR DESCRIPTION
In this PR we run all command in --no-interaction, 

Also added : 

```
  if [ "$LOAD_FIXTURES" = 'true' ]; then
        bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm --purge-with-truncate
        bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
    fi
```

Required to load fixture when backend is loaded with CI env variable set to true and dev set to false.

The existing one doesn't fit the initial requirement : 
```
if [ "$APP_ENV" = 'dev' ] && [ "$NEED_FIXTURES" = 'true' ]; then
        bin/console doctrine:fixtures:load --group=crm_minimal -vv -n --em=crm --purge-with-truncate
        bin/console doctrine:fixtures:load --group=hoz_minimal -vv -n --purge-with-truncate
fi
```

Added : 

platform specification to avoid conflicts when building from macOS